### PR TITLE
Use wildcard selectors for adding action links

### DIFF
--- a/auto-bazaar-pricer.user.js
+++ b/auto-bazaar-pricer.user.js
@@ -177,7 +177,8 @@ $(() => {
                     $(`<a class="${classes} auto-pricer-configure">Configure</a>`),
                     $(`<a class="${classes} auto-pricer-start">Start FATU\'s Pricer</a>`)
                 ];
-                $container.prepend(buttons);
+                
+                container.prepend(buttons);
 
                 this.elements = {
                     start: buttons[1],

--- a/auto-bazaar-pricer.user.js
+++ b/auto-bazaar-pricer.user.js
@@ -177,7 +177,7 @@ $(() => {
                     $(`<a class="${classes} auto-pricer-configure">Configure</a>`),
                     $(`<a class="${classes} auto-pricer-start">Start FATU\'s Pricer</a>`)
                 ];
-                
+
                 container.prepend(buttons);
 
                 this.elements = {

--- a/auto-bazaar-pricer.user.js
+++ b/auto-bazaar-pricer.user.js
@@ -50,7 +50,7 @@ $(() => {
                 type: 'number'
             }
         },
-        options = /*GM_getValue(storage) ||*/ defaults;
+        options = GM_getValue(storage) || defaults;
 
     // Configuration methods.
     var configuration = {

--- a/auto-bazaar-pricer.user.js
+++ b/auto-bazaar-pricer.user.js
@@ -169,14 +169,9 @@ $(() => {
              * Create element and add to page.
              */
             build: function () {
-                var $container = $('[class^="linksContainer_"');
-                var $link = $('[class^="linkContainer_"');
-                var classes = '';
-                for (const cls of $link.get(0).classList.values()) {
-                    if (cls.indexOf('__') >= 0) {
-                        classes += cls + ' ';
-                    }
-                }
+                const container = $('[class^="linksContainer_"'),
+                    link = $('[class^="linkContainer_"'),
+                    classes = link[0].className;
 
                 var buttons = [
                     $(`<a class="${classes}auto-pricer-configure">Configure</a>`),

--- a/auto-bazaar-pricer.user.js
+++ b/auto-bazaar-pricer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn - Bazaar Pricer
 // @namespace    https://github.com/danielgoodwin97/torn-bazaar-pricer
-// @version      1.5.9
+// @version      1.5.10
 // @description  Automatically price & add quantity to bazaar items.
 // @author       FATU [1482556]
 // @match        *.torn.com/bazaar.php*
@@ -50,7 +50,7 @@ $(() => {
                 type: 'number'
             }
         },
-        options = GM_getValue(storage) || defaults;
+        options = /*GM_getValue(storage) ||*/ defaults;
 
     // Configuration methods.
     var configuration = {
@@ -169,12 +169,20 @@ $(() => {
              * Create element and add to page.
              */
             build: function () {
-                var buttons = [
-                    $('<a class="linkContainer___1dLm- inRow___2mEag greyLineV___2_WJ8 auto-pricer-configure">Configure</a>'),
-                    $('<a class="linkContainer___1dLm- inRow___2mEag greyLineV___2_WJ8 auto-pricer-start">Start FATU\'s Pricer</a>')
-                ];
+                var $container = $('[class^="linksContainer_"');
+                var $link = $('[class^="linkContainer_"');
+                var classes = '';
+                for (const cls of $link.get(0).classList.values()) {
+                    if (cls.indexOf('__') >= 0) {
+                        classes += cls + ' ';
+                    }
+                }
 
-                $('.linksContainer___3r-Lt').prepend(buttons);
+                var buttons = [
+                    $(`<a class="${classes}auto-pricer-configure">Configure</a>`),
+                    $(`<a class="${classes}auto-pricer-start">Start FATU\'s Pricer</a>`)
+                ];
+                $container.prepend(buttons);
 
                 this.elements = {
                     start: buttons[1],

--- a/auto-bazaar-pricer.user.js
+++ b/auto-bazaar-pricer.user.js
@@ -174,8 +174,8 @@ $(() => {
                     classes = link[0].className;
 
                 var buttons = [
-                    $(`<a class="${classes}auto-pricer-configure">Configure</a>`),
-                    $(`<a class="${classes}auto-pricer-start">Start FATU\'s Pricer</a>`)
+                    $(`<a class="${classes} auto-pricer-configure">Configure</a>`),
+                    $(`<a class="${classes} auto-pricer-start">Start FATU\'s Pricer</a>`)
                 ];
                 $container.prepend(buttons);
 


### PR DESCRIPTION
fixed a problem where it wasn't matching the correct classes anymore after the Torn frontend was updated and the class hashes were regenerated.